### PR TITLE
Add parameter for AdvertiseAddress

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -28,6 +28,7 @@
   },
   "restAPI": {
     "bindAddress": "localhost:9092",
+    "advertiseAddress": "",
     "debugRequestLoggerEnabled": false
   },
   "spammer": {

--- a/core/spammer/component.go
+++ b/core/spammer/component.go
@@ -260,7 +260,12 @@ func run() error {
 
 		ctxRegister, cancelRegister := context.WithTimeout(ctx, 5*time.Second)
 
-		if err := deps.NodeBridge.RegisterAPIRoute(ctxRegister, APIRoute, ParamsRestAPI.BindAddress); err != nil {
+		advertisedAddress := ParamsRestAPI.BindAddress
+		if ParamsRestAPI.AdvertiseAddress != "" {
+			advertisedAddress = ParamsRestAPI.AdvertiseAddress
+		}
+
+		if err := deps.NodeBridge.RegisterAPIRoute(ctxRegister, APIRoute, advertisedAddress); err != nil {
 			CoreComponent.LogErrorfAndExit("Registering INX api route failed: %s", err)
 		}
 		cancelRegister()

--- a/core/spammer/params.go
+++ b/core/spammer/params.go
@@ -50,10 +50,12 @@ type ParametersSpammer struct {
 	}
 }
 
-// ParametersRestAPI contains the definition of the parameters used by REST API.
+// ParametersRestAPI contains the definition of the parameters used by the Spammer HTTP server.
 type ParametersRestAPI struct {
 	// BindAddress defines the bind address on which the Spammer HTTP server listens.
 	BindAddress string `default:"localhost:9092" usage:"the bind address on which the Spammer HTTP server listens"`
+	// AdvertiseAddress defines the address of the Spammer HTTP server which is advertised to the INX Server (optional).
+	AdvertiseAddress string `default:"" usage:"the address of the Spammer HTTP server which is advertised to the INX Server (optional)"`
 	// DebugRequestLoggerEnabled defines whether the debug logging for requests should be enabled
 	DebugRequestLoggerEnabled bool `default:"false" usage:"whether the debug logging for requests should be enabled"`
 }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -135,10 +135,11 @@ Example:
 
 ## <a id="restapi"></a> 5. RestAPI
 
-| Name                      | Description                                               | Type    | Default value    |
-| ------------------------- | --------------------------------------------------------- | ------- | ---------------- |
-| bindAddress               | The bind address on which the Spammer HTTP server listens | string  | "localhost:9092" |
-| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled  | boolean | false            |
+| Name                      | Description                                                                             | Type    | Default value    |
+| ------------------------- | --------------------------------------------------------------------------------------- | ------- | ---------------- |
+| bindAddress               | The bind address on which the Spammer HTTP server listens                               | string  | "localhost:9092" |
+| advertiseAddress          | The address of the Spammer HTTP server which is advertised to the INX Server (optional) | string  | ""               |
+| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled                                | boolean | false            |
 
 Example:
 
@@ -146,6 +147,7 @@ Example:
   {
     "restAPI": {
       "bindAddress": "localhost:9092",
+      "advertiseAddress": "",
       "debugRequestLoggerEnabled": false
     }
   }


### PR DESCRIPTION
This PR introduces the AdvertiseAddress config parameter, which simplifies the setup in some private network environments.